### PR TITLE
Fix use-after-free of fd

### DIFF
--- a/src/dmidecode/util.c
+++ b/src/dmidecode/util.c
@@ -162,6 +162,5 @@ void *mem_chunk(size_t base, size_t len, const char *devmem)
 	if(close(fd)==-1)
 		perror(devmem);
 
-	close(fd);
 	return p;
 }


### PR DESCRIPTION
This bug got introduced in 51219cac581b5eaced5b172dbbb4586889cb27e1. I
overlooked that we are already properly closing fd on non-error code
path and I added redundant call to close.

Closing already closed fd is harmless though. Function returns EBADF and
fails silently.
