### PR TITLE
Ignore naming of non-Ethernet network interfaces

### DIFF
--- a/src/bios_device.c
+++ b/src/bios_device.c
@@ -238,6 +238,9 @@ static void match_pci_and_eth_devs(struct libbiosdevname_state *state)
 		/* Loop through all ether devices to find match */
 		unparse_pci_name(pci_name, sizeof(pci_name), p->pci_dev);
 		list_for_each_entry(n, &state->network_devices, node) {
+			//Accept only Ethernet devices, otherwise ignore.
+			if(!netdev_arphrd_type_is_eth(n))
+				continue;
 			if (strncmp(n->drvinfo.bus_info, pci_name, sizeof(n->drvinfo.bus_info)))
 				continue;
 			/* Ignore if devtype is fcoe */

--- a/src/eths.h
+++ b/src/eths.h
@@ -63,4 +63,9 @@ static inline int netdev_devtype_is_fcoe(const struct network_device *dev)
 	return (dev->devtype_is_fcoe == 1);
 }
 
+static inline int netdev_arphrd_type_is_eth(const struct network_device *dev)
+{
+        return (dev->arphrd_type == ARPHRD_ETHER);
+}
+
 #endif /* __ETHS_H_INCLUDED */


### PR DESCRIPTION
Support of biosdevname is to name Ethernet interfaces only, as per biosdevname spec.
Currently, manual call of biosdevname on other types of network interfaces will return interface names.
This code change is to ignore naming of Infiniband and other types of network interfaces.