### PR TITLE
Add support for ExaNIC network cards

### DIFF
--- a/src/bios_device.c
+++ b/src/bios_device.c
@@ -221,6 +221,8 @@ int ismultiport(const char *driver)
 		return 1;
 	if (!strncmp(driver, "cxgb", 4))
 		return 1;
+	if (!strncmp(driver, "exanic", 6))
+		return 1;
 	return 0;
 }
 


### PR DESCRIPTION
ExaNIC cards have multiple physical ports on the same PCI function and
need to be numbered using the dev_port attribute.