### PR TITLE
Prevent infinite recursion in dmidecode.c::smbios_setslot

### DIFF
--- a/src/dmidecode/dmidecode.c
+++ b/src/dmidecode/dmidecode.c
@@ -153,7 +153,7 @@ void smbios_setslot(const struct libbiosdevname_state *state,
 		}
     
 		/* Found a PDEV, now is it a bridge? */
-		if (pdev->sbus != -1) {
+		if (pdev->sbus != -1  && pdev->sbus > bus) {
 			smbios_setslot(state, domain, pdev->sbus, -1, -1, type, slot, index, label);
 		}
 	}


### PR DESCRIPTION
... by checking that subordinate bus has a number greater than the
current bus.