### PR TITLE
Netronome biosdevname support

### DIFF
--- a/src/bios_device.c
+++ b/src/bios_device.c
@@ -250,6 +250,8 @@ static void match_pci_and_eth_devs(struct libbiosdevname_state *state)
 			/* Ignore if devtype is fcoe */
 			if (netdev_devtype_is_fcoe(n))
 				continue;
+			if (!netdev_is_eligible(n))
+				continue;
 			b = malloc(sizeof(*b));
 			if (!b)
 				continue;

--- a/src/bios_device.c
+++ b/src/bios_device.c
@@ -214,7 +214,7 @@ static void sort_device_list(struct libbiosdevname_state *state)
 	list_splice(&sorted_devices, &state->bios_devices);
 }
 
-/* Check for Mellanox/Chelsio drivers */
+/* Check for multiport drivers */
 int ismultiport(const char *driver)
 {
 	if (!strncmp(driver, "mlx4", 4))
@@ -222,6 +222,8 @@ int ismultiport(const char *driver)
 	if (!strncmp(driver, "cxgb", 4))
 		return 1;
 	if (!strncmp(driver, "exanic", 6))
+		return 1;
+	if (!strncmp(driver, "nfp", 3))
 		return 1;
 	return 0;
 }

--- a/src/eths.c
+++ b/src/eths.c
@@ -61,6 +61,18 @@ static int eths_get_phys_port_name_id(const char *devname)
 	return index;
 }
 
+static void eths_get_dev_eligible(struct network_device *dev)
+{
+	/* By default, all network devices are eligible for naming. Some may
+	 * opt-out explicitly below.
+	 */
+	dev->is_eligible = 1;
+
+	if (dev->drvinfo_valid && strcmp(dev->drvinfo.driver, "nfp") == 0) {
+		dev->is_eligible = (eths_get_phys_port_name_id(dev->kernel_name) >= 0 ? 1 : 0);
+	}
+}
+
 static void eths_get_devid(struct network_device *dev)
 {
 	char path[PATH_MAX];
@@ -265,6 +277,7 @@ static void fill_eth_dev(struct network_device *dev)
 	if (rc == 0)
 		dev->drvinfo_valid = 1;
 	eths_get_devid(dev);
+	eths_get_dev_eligible(dev);
 }
 
 void free_eths(struct libbiosdevname_state *state)

--- a/src/eths.h
+++ b/src/eths.h
@@ -30,6 +30,7 @@ struct network_device {
 	int devid;
 	int devtype_is_fcoe;
 	char *devtype;
+	int is_eligible:1; /* not eligible for naming when 0 */
 };
 
 extern void get_eths(struct libbiosdevname_state *state);
@@ -66,6 +67,11 @@ static inline int netdev_devtype_is_fcoe(const struct network_device *dev)
 static inline int netdev_arphrd_type_is_eth(const struct network_device *dev)
 {
         return (dev->arphrd_type == ARPHRD_ETHER);
+}
+
+static inline int netdev_is_eligible(const struct network_device *dev)
+{
+	return (!!dev->is_eligible);
 }
 
 #endif /* __ETHS_H_INCLUDED */


### PR DESCRIPTION
Netronome NICs behave similar to some other vendors that have multiple
ports per physical function. However, additionally, one of our firmware
loads, for OVS-TC offload, presents quite a different view.

In this case, there are multiple representors and a data vNIC used for
transfering multiplexed traffic to the representors devices. If you are
interested, we can describe the representor architecture a bit more, but
the point is, this view doesn't quite fit into any current naming scheme
provided by biosdevname.

The patch series resolves this by allowing some drivers, nfp.ko only in
this case, to exclude some devices from being named by biosdevname. We
only want to name the MAC representor devices to the normal pXpY name.
To do this correctly, we also need to use the phys_port_name attribute
which systemd generally uses for naming. VFs are not affected since they
use the nfp_netvf.ko driver, excluded from this conditional code.

Furthermore, splitting the ports on the Netronome NIC results in names
such as enpXs0npYsZ. We don't really want to handle these through
biosdevname since its a corner case and there also isn't an explicit
definition for split ports defined in biosdevname.

There is a Redhat bugzilla filed relating to this problem, BZ #816536.
We'd want to get this fix in in time for RHEL 8.0.