### PR TITLE
man: fix all_ethN indentation

### DIFF
--- a/biosdevname.1
+++ b/biosdevname.1
@@ -60,7 +60,7 @@ for embedded NICs
 p<slot>p<port>[_<virtual instance>]
 for cards in PCI slots
 .br
-.TP
+.PP
 The
 .B all_ethN
 policy makes a best guess at what the device order should be, with


### PR DESCRIPTION
all_ethN is not another .TP block under the physical policy, it is a paragraph of its own right.