### PR TITLE
Improvements for running biosdevname in virtual machines

### DIFF
--- a/src/bios_dev_name.c
+++ b/src/bios_dev_name.c
@@ -119,28 +119,33 @@ parse_opts(int argc, char **argv)
 static u_int32_t
 cpuid (u_int32_t eax, u_int32_t ecx)
 {
-    asm volatile (
-        "xor %%ebx, %%ebx; cpuid"
-        : "=a" (eax),  "=c" (ecx)
-        : "a" (eax)
-	: "%ebx", "%edx");
-    return ecx;
+#if defined(__x86_64__) || defined(__i386__)
+	asm volatile (
+		"xor %%ebx, %%ebx; cpuid"
+		: "=a" (eax),  "=c" (ecx)
+		: "a" (eax)
+		: "%ebx", "%edx");
+	return ecx;
+#else
+	return 0;
+#endif
 }
-
-/*
-  Algorithm suggested by:
-  http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1009458
-*/
 
 static int
 running_in_virtual_machine (void)
 {
-    u_int32_t eax=1U, ecx=0U;
+#if defined(__x86_64__) || defined(__i386__)
+	/* Algorithm suggested by https://kb.vmware.com/s/article/1009458 */
+	u_int32_t eax=1U, ecx=0U;
 
-    ecx = cpuid (eax, ecx);
-    if (ecx & 0x80000000U)
-       return 1;
+	ecx = cpuid (eax, ecx);
+	if (ecx & 0x80000000U)
+		return 1;
+	else
+		return 0;
+#else
     return 0;
+#endif
 }
 
 static int


### PR DESCRIPTION
Right now, biosdevname completely and _silently_ refuses to run in virtual machines. In reality, it works in most VMs just fine, so there should be at least an option to allow that, and an error message to explain why it refuses to run and what to do.

Also, the VM check is specific to x86.

* Add an option to allow running biosdevname in VMs: `-V`, `--allow-vm`
* Add an error message when trying to run it in a VM without that option.
* Limit the CPUID check to x86 CPUs, effectively disable it on other architectures for now.